### PR TITLE
feat(security): implement global method-level security with role-based authorization

### DIFF
--- a/infrastructure/src/main/java/com/fernirx/lms/infrastructure/config/SecurityConfig.java
+++ b/infrastructure/src/main/java/com/fernirx/lms/infrastructure/config/SecurityConfig.java
@@ -9,6 +9,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -20,6 +21,7 @@ import org.springframework.web.cors.CorsConfigurationSource;
 
 @Configuration
 @EnableWebSecurity
+@EnableMethodSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
     private final JwtAuthenticationFilter jwtAuthenticationFilter;

--- a/user/src/main/java/com/fernirx/lms/user/controller/UserController.java
+++ b/user/src/main/java/com/fernirx/lms/user/controller/UserController.java
@@ -11,6 +11,7 @@ import com.fernirx.lms.user.service.UserService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -24,6 +25,7 @@ public class UserController {
 
     @GetMapping
     @StandardResponseDoc(value = "Get users by status")
+    @PreAuthorize("hasAnyRole('ADMIN', 'DEPT_HEAD', 'ACAD_AFFAIRS')")
     public ResponseEntity<SuccessResponse<List<UserResponse>>> getUsersByStatus(
             @RequestParam(required = false, defaultValue = "false") boolean status) {
         List<UserResponse> users = userService.getUsersByStatus(status);
@@ -38,6 +40,7 @@ public class UserController {
             value = "Get a user",
             description = "Get a user by ID from LMS System"
     )
+    @PreAuthorize("hasAnyRole('ADMIN', 'DEPT_HEAD', 'ACAD_AFFAIRS') or #id == authentication.principal.id")
     public ResponseEntity<SuccessResponse<UserResponse>> getUserById(@PathVariable Long id) {
         UserResponse user = userService.getUserById(id);
         return ResponseEntity.ok(SuccessResponse.of(
@@ -51,6 +54,7 @@ public class UserController {
             value = "Create a user",
             description = "Create a new user in the LMS System with Username, Password, RoleId"
     )
+    @PreAuthorize("hasAnyRole('ADMIN', 'ACAD_AFFAIRS')")
     public ResponseEntity<SuccessResponse<UserResponse>> createUser(
             @Valid @RequestBody UserCreateRequest request) {
         UserResponse userResponse = userService.createUser(request);
@@ -65,6 +69,7 @@ public class UserController {
             value = "Update user information",
             description = "Update user information in the LMS System"
     )
+    @PreAuthorize("hasAnyRole('ADMIN', 'ACAD_AFFAIRS')")
     public ResponseEntity<SuccessResponse<UserResponse>> updateUser(
             @PathVariable Long id,
             @Valid @RequestBody UserUpdateRequest request) {
@@ -80,6 +85,7 @@ public class UserController {
             value = "Delete a user",
             description = "Soft delete a user by ID from LMS System"
     )
+    @PreAuthorize("hasAnyRole('ADMIN')")
     public ResponseEntity<SuccessResponse<Void>> deleteUser(@PathVariable Long id) {
         userService.softDeleteUser(id);
         return ResponseEntity.ok(SuccessResponse.of(
@@ -92,6 +98,7 @@ public class UserController {
             value = "Restore user",
             description = "Restore user activity status"
     )
+    @PreAuthorize("hasAnyRole('ADMIN')")
     public ResponseEntity<SuccessResponse<Void>> restoreUser(@PathVariable Long id) {
         userService.restoreUser(id);
         return ResponseEntity.ok(SuccessResponse.of(


### PR DESCRIPTION
## Summary
  - Enabled global method-level security with `@EnableMethodSecurity` annotation
  - Implemented role-based authorization on all UserController endpoints using `@PreAuthorize`
  - Ensured auth and password recovery endpoints remain publicly accessible

  ## Changes
  - **SecurityConfig**: Added `@EnableMethodSecurity` to enable method-level security annotations
  - **UserController**: Applied `@PreAuthorize` annotations to all endpoints with appropriate role restrictions
    - List users: `ADMIN`, `DEPT_HEAD`, `ACAD_AFFAIRS`
    - Get user by ID: `ADMIN`, `DEPT_HEAD`, `ACAD_AFFAIRS`, or own user
    - Create user: `ADMIN`, `ACAD_AFFAIRS`
    - Update user: `ADMIN`, `ACAD_AFFAIRS`
    - Delete user: `ADMIN` only
    - Restore user: `ADMIN` only
  - **AuthController & PasswordController**: Verified public access maintained via SecurityConfig

  ## Security
  - All authenticated endpoints now properly enforce role-based access control
  - Public endpoints (login, password reset) remain unrestricted
  - Users can view their own profile data